### PR TITLE
Remove product references

### DIFF
--- a/source/overview/index.html.md.erb
+++ b/source/overview/index.html.md.erb
@@ -20,5 +20,5 @@ With the provided functionality, you should be able to build things using up-to-
 data from the Explore education statistics service. Potential ideas for this may include:
 
 - applications and websites
-- dashboards and charts e.g. using PowerBI, RShiny, etc
+- dashboards and charts
 - scheduled reports


### PR DESCRIPTION
Been flagged to us that we shouldn't be seen to endorse any particular software so removing these references from the initial overview to avoid confusion around this and also before I forget to do this at a later point!

I don't know how the build / deploy of these pages work or if there's any additional work needed before merging, so raising this for now and hopefully @ntsim you can help sort that side?