### PR TITLE
EES-3860 - setup alerts for out of date API docs

### DIFF
--- a/.github/workflows/notify-expired.yml
+++ b/.github/workflows/notify-expired.yml
@@ -1,0 +1,22 @@
+name: Notify expired documentation
+on:
+  schedule:
+    - cron: '5 12 * * 1-5'  # 12:05 UTC, Monday to Friday
+  workflow_dispatch:
+
+jobs:
+  daniel_the_manual_spaniel:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+
+      - name: notify:expired
+        run: bundle exec rake notify:expired
+        env:
+          REALLY_POST_TO_SLACK: ${{ (github.event_name == 'schedule') && 1 || 0 }}
+          SLACK_TOKEN: ${{ secrets.SLACK_TOKEN }}

--- a/Gemfile
+++ b/Gemfile
@@ -15,3 +15,9 @@ gem 'html-proofer'
 
 # Temporary fix for https://github.com/middleman/middleman/issues/2569
 gem 'haml', '~> 5.0'
+
+gem 'chronic'
+
+gem 'http'
+
+gem 'rake'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -33,6 +33,8 @@ GEM
       sass (>= 3.2, < 3.5)
     concurrent-ruby (1.1.10)
     contracts (0.13.0)
+    domain_name (0.5.20190701)
+      unf (>= 0.0.5, < 1.0.0)
     dotenv (2.8.1)
     em-websocket (0.5.3)
       eventmachine (>= 0.12.9)
@@ -45,6 +47,9 @@ GEM
     fast_blank (1.0.1)
     fastimage (2.2.6)
     ffi (1.15.5)
+    ffi-compiler (1.0.1)
+      ffi (>= 1.0.0)
+      rake
     govuk_tech_docs (3.2.1)
       autoprefixer-rails (~> 10.2)
       chronic (~> 0.10.2)
@@ -73,6 +78,14 @@ GEM
       typhoeus (~> 1.3)
       yell (~> 2.0)
       zeitwerk (~> 2.5)
+    http (5.1.1)
+      addressable (~> 2.8)
+      http-cookie (~> 1.0)
+      http-form_data (~> 2.2)
+      llhttp-ffi (~> 0.4.0)
+    http-cookie (1.0.5)
+      domain_name (~> 0.5)
+    http-form_data (2.3.0)
     http_parser.rb (0.8.0)
     i18n (1.6.0)
       concurrent-ruby (~> 1.0)
@@ -81,6 +94,9 @@ GEM
     listen (3.0.8)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
+    llhttp-ffi (0.4.0)
+      ffi-compiler (~> 1.0)
+      rake (~> 13.0)
     memoist (0.16.2)
     mercenary (0.4.0)
     middleman (4.4.2)
@@ -184,6 +200,9 @@ GEM
       concurrent-ruby (~> 1.0)
     uglifier (3.2.0)
       execjs (>= 0.3.0, < 3)
+    unf (0.1.4)
+      unf_ext
+    unf_ext (0.0.8.2)
     webrick (1.7.0)
     yell (2.2.2)
     zeitwerk (2.6.0)
@@ -192,10 +211,13 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  chronic
   govuk_tech_docs
   haml (~> 5.0)
   html-proofer
+  http
   middleman-gh-pages
+  rake
   tzinfo-data
   wdm (~> 0.1.0)
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,45 @@
+require_relative './lib/notifier'
+require 'chronic'
+
+task default: ["notify:expired"]
+
+namespace :notify do
+  pages_urls = [
+    "https://dfe-analytical-services.github.io/explore-education-statistics-api-docs/api/pages.json"
+  ]
+
+  limits = {
+  }
+
+  live = ENV.fetch("REALLY_POST_TO_SLACK", 0) == "1"
+  slack_url = ENV["SLACK_WEBHOOK_URL"]
+  slack_token = ENV["SLACK_TOKEN"]
+
+  if live && (!slack_url && !slack_token) then
+    fail "If you want to post to Slack you need to set SLACK_TOKEN or SLACK_WEBHOOK_URL"
+  end
+
+  desc "Notifies of all pages which have expired"
+  task :expired do
+    notification = Notification::Expired.new
+
+    pages_urls.each do |page_url|
+      puts "== #{page_url}"
+
+      Notifier.new(notification, page_url, slack_url, live, limits.fetch(page_url, -1)).run
+    end
+  end
+
+  desc "Notifies of all pages which will expire soon"
+  task :expires, :timeframe do |_, args|
+    args.with_defaults(timeframe: "in 1 month")
+    expire_by = Chronic.parse(args[:timeframe]).to_date
+    notification = Notification::WillExpireBy.new(expire_by)
+
+    pages_urls.each do |page_url|
+      puts "== #{page_url}"
+
+      Notifier.new(notification, page_url, slack_url, live).run
+    end
+  end
+end

--- a/lib/notification/expired.rb
+++ b/lib/notification/expired.rb
@@ -1,0 +1,29 @@
+require 'date'
+
+module Notification
+  class Expired
+    def include?(page)
+      page.review_by <= Date.today
+    end
+
+    def line_for(page)
+      age = (Date.today - page.review_by).to_i
+      expired_when = if page.review_by == Date.today
+                       "today"
+                     elsif age == 1
+                       "yesterday"
+                     else
+                       "#{age} days ago"
+                     end
+      "- <#{page.url}|#{page.title}> (#{expired_when})"
+    end
+
+    def singular_message
+        "I've found a page that is due for review"
+    end
+
+    def multiple_message
+        "I've found %s pages that are due for review"
+    end
+  end
+end

--- a/lib/notification/will_expire_by.rb
+++ b/lib/notification/will_expire_by.rb
@@ -1,0 +1,33 @@
+require 'date'
+
+module Notification
+  class WillExpireBy
+    def initialize(expiry_date)
+      @expiry_date = expiry_date
+    end
+
+    def include?(page)
+      page.review_by > Date.today && page.review_by <= @expiry_date
+    end
+
+    def line_for(page)
+      age = (page.review_by - Date.today).to_i
+      expires_when = if page.review_by == Date.today
+                       "today"
+                     elsif age == 1
+                       "tomorrow"
+                     else
+                       "in #{age} days"
+                     end
+      "- <#{page.url}|#{page.title}> (#{expires_when})"
+    end
+
+    def singular_message
+        "I've found a page that will expire on or before #{@expiry_date}"
+    end
+
+    def multiple_message
+        "I've found %s pages that will expire on or before #{@expiry_date}"
+    end
+  end
+end

--- a/lib/notifier.rb
+++ b/lib/notifier.rb
@@ -1,0 +1,140 @@
+require 'http'
+require 'json'
+require 'date'
+require 'uri'
+
+require_relative './page'
+require_relative './notification/expired'
+require_relative './notification/will_expire_by'
+
+class Notifier
+  def initialize(notification, pages_url, slack_url, live, limit = -1)
+    @notification = notification
+    @pages_url = pages_url
+    @slack_url = slack_url
+    @live = !!live
+    @limit = limit
+  end
+
+  def run
+    payloads = message_payloads(pages_per_channel)
+
+    return if payloads.empty?
+
+    puts "== JSON Payload:"
+    puts JSON.pretty_generate(payloads)
+
+    if Date.today.saturday? || Date.today.sunday?
+      puts "SKIPPING POST: Not posting anything, this is not a working day"
+      return
+    end
+
+    unless post_to_slack?
+      puts "SKIPPING POST: Not posting anything, this is a dry run"
+      return
+    end
+
+    payloads.each do |message_payload|
+      if ENV.has_key? "SLACK_TOKEN"
+        response = HTTP
+          .auth("Bearer #{ENV['SLACK_TOKEN']}")
+          .post("https://slack.com/api/chat.postMessage", json: message_payload)
+          .parse
+
+        if !response["ok"] then
+          if response["error"] == "invalid_auth" then
+            raise "Unable to post to Slack: SLACK_TOKEN is not valid"
+          else
+            puts "Unable to post to Slack: #{response['error']}"
+          end
+        end
+      else
+        HTTP.post(@slack_url, body: JSON.dump(message_payload))
+      end
+    end
+  end
+
+  def pages
+    begin
+      JSON.parse(HTTP.get(@pages_url)).map { |data|
+        data['url'] = get_absolute_url(data['url'])
+        Page.new(data)
+      }
+    rescue => exception
+      warn "Notifier: could not get pages for tech docs at #{@pages_url}"
+      warn exception.message
+      return []
+    end
+  end
+
+  def pages_per_channel
+    pages
+      .reject { |page| page.review_by.nil? }
+      .select { |page| @notification.include?(page) }
+      .group_by { |page| page.owner }
+      .map do |owner, pages|
+        [owner, pages.sort_by { |page| page.review_by }]
+      end
+  end
+
+  def message_payloads(grouped_pages)
+    grouped_pages.map do |channel, pages|
+
+      page_count = @limit == -1 ? pages.size : [pages.size, @limit].min
+      notification_message = page_count == 1 ? @notification.singular_message : @notification.multiple_message
+      number_of = notification_message % [page_count]
+
+      page_lines = pages[0..page_count-1].map do |page|
+        @notification.line_for(page)
+      end
+
+      message_prefix = ENV.fetch('OVERRIDE_SLACK_MESSAGE_PREFIX', "Hello :paw_prints:, this is your friendly manual spaniel.")
+      message = <<~doc
+        #{message_prefix} #{number_of}:
+
+        #{page_lines.join("\n")}
+      doc
+
+      channel = ENV.fetch('OVERRIDE_SLACK_CHANNEL', channel)
+      username = ENV.fetch('OVERRIDE_SLACK_USERNAME', "Daniel the Manual Spaniel")
+      icon_emoji = ENV.fetch('OVERRIDE_SLACK_ICON_EMOJI', ":daniel-the-manual-spaniel:")
+
+      puts "== Message to #{channel}"
+      puts message
+
+      {
+        username: username,
+        icon_emoji: icon_emoji,
+        text: message,
+        mrkdwn: true,
+        channel: channel,
+      }
+    end
+  end
+
+  def post_to_slack?
+    @live
+  end
+
+  private
+
+  def get_absolute_url url
+    target_uri = URI(url)
+    target_path = Pathname.new(target_uri.path)
+    source_uri = URI(@pages_url)
+
+    if target_path.relative?
+      resulting_path = URI::join(source_uri, target_uri.path).path
+    else
+      resulting_path = target_uri.path
+    end
+
+    if source_uri.scheme == 'https'
+      URI::HTTPS.build(scheme: source_uri.scheme, port: source_uri.port, host: source_uri.host, path: resulting_path).to_s
+    else
+      URI::HTTP.build(scheme: source_uri.scheme, port: source_uri.port, host: source_uri.host, path: resulting_path).to_s
+end
+  end
+end
+
+

--- a/lib/page.rb
+++ b/lib/page.rb
@@ -1,0 +1,12 @@
+require 'date'
+
+class Page
+  attr_reader :url, :title, :review_by, :owner
+
+  def initialize(page_data)
+    @url       = page_data["url"]
+    @title     = page_data["title"]
+    @review_by = page_data["review_by"].nil? ? nil : Date.parse(page_data["review_by"])
+    @owner     = page_data["owner_slack"]
+  end
+end


### PR DESCRIPTION
This PR
* Adds [Daniel the Spaniel](https://github.com/alphagov/tech-docs-monitor) to the project which enables slack alerts to be sent to the `alerts` channel in order to notify us when API documentation needs to be reviewed/is out of date. It seems this slack util isn't distributed as a gem so I've manually added it to the project.

As part of testing, I've used the endpoint `https://tech-docs-json.vercel.app/api/pages` that responds with out-of-date documentation to test that slack notifications get sent for out-of-date documentation. The relevant `SLACK_TOKEN` has been added to the repository's secrets so that it can be accessed in CI runs